### PR TITLE
Potential fix for code scanning alert no. 9: Shell command built from environment values

### DIFF
--- a/tests/node_compat/test/parallel/test-child-process-exec-maxbuf.js
+++ b/tests/node_compat/test/parallel/test-child-process-exec-maxbuf.js
@@ -33,20 +33,21 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd =
-    `${process.execPath} eval "console.log('a'.repeat(1024 * 1024 - 1))"`;
+  const cmd = process.execPath;
+  const args = ['eval', "console.log('a'.repeat(1024 * 1024 - 1))"];
 
-  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  cp.execFile(cmd, args, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
 }
 
 {
-  const cmd = `"${process.execPath}" eval "console.log('hello world');"`;
+  const cmd = process.execPath;
+  const args = ['eval', "console.log('hello world');"];
   const options = { maxBuffer: Infinity };
 
-  cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
+  cp.execFile(cmd, args, options, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'hello world');
     assert.strictEqual(stderr, '');
   }));


### PR DESCRIPTION
Potential fix for [https://github.com/octodevark/deno/security/code-scanning/9](https://github.com/octodevark/deno/security/code-scanning/9)

To fix the issue, the shell command should be constructed using `cp.execFile` or `cp.execFileSync` instead of `cp.exec`. These methods allow passing arguments separately, avoiding interpretation by the shell and mitigating the risk of command injection or misbehavior due to special characters. Specifically, the `process.execPath` value and other arguments should be passed as separate elements in an array.

The changes will involve:
1. Replacing the dynamic construction of `cmd` with an array of arguments.
2. Updating the `cp.exec` calls to use `cp.execFile` with the appropriate arguments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
